### PR TITLE
Fix db:schema:dump & the testsuite. 

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -73,6 +73,27 @@ This is equivalent to:
 * The "SET SCHEMA" fragment of the ALTER command is not implemented.
 * Oracle/other databases not supported
 * Other unknown bugs :)
+
+== Testing
+There are some unit tests in place, implemented using [test-unit](https://github.com/test-unit/test-unit).
+
+To run the testsuite:
+
+  rake test
+
+And you should see something like:
+
+  ...
+  Loaded suite ...
+  Started
+  ......................
+
+  Finished in 0.005055 seconds.
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  22 tests, 33 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
+  100% passed
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  4352.13 tests/s, 6528.19 assertions/s
   
 == References
 * http://www.postgresql.org/docs/8.1/static/sql-createsequence.html

--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -1,18 +1,18 @@
 module PgSequencer
   module SchemaDumper
     extend ActiveSupport::Concern
-    
+
     included do
       alias_method_chain :tables, :sequences
     end
-    
+
     def tables_with_sequences(stream)
       tables_without_sequences(stream)
-      sequences(stream)
+      sequences
     end
-    
+
     private
-    def sequences(stream)
+    def sequences
       sequence_statements = @connection.sequences.map do |sequence|
         statement_parts = [ ('create_sequence ') + sequence.name.inspect ]
         statement_parts << (':increment => ' + sequence.options[:increment].inspect)
@@ -21,12 +21,11 @@ module PgSequencer
         statement_parts << (':start => ' + sequence.options[:start].inspect)
         statement_parts << (':cache => ' + sequence.options[:cache].inspect)
         statement_parts << (':cycle => ' + sequence.options[:cycle].inspect)
-        
+
         '  ' + statement_parts.join(', ')
       end
-      
-      stream.puts sequence_statements.sort.join("\n")
-      stream.puts
+
+      @dump.final << sequence_statements.sort.join("\n").strip
     end
   end
 end

--- a/pg_sequencer.gemspec
+++ b/pg_sequencer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   # s.add_dependency "rails", "~> 3.1.0"
-  s.add_dependency 'activerecord', '>= 3.1.0', '>= 3.0.0'
+  s.add_dependency 'activerecord', '>= 3.1.0'
   s.add_development_dependency "pg", "0.11.0"
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-test"

--- a/test/unit/postgresql_adapter_test.rb
+++ b/test/unit/postgresql_adapter_test.rb
@@ -1,9 +1,9 @@
 require 'helper'
 require 'pg_sequencer/connection_adapters/postgresql_adapter'
 
-class PostgreSQLAdapterTest < ActiveSupport::TestCase
+class PostgreSQLAdapterTest < Test::Unit::TestCase
   include PgSequencer::ConnectionAdapters::PostgreSQLAdapter
-  
+
   setup do
     @options = {
       :increment => 1,
@@ -13,61 +13,61 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
       :cycle     => true
     }
   end
-  
+
   context "generating sequence option SQL" do
     context "for :increment" do
       should "include 'INCREMENT BY' in the SQL" do
         assert_equal(" INCREMENT BY 1", sequence_options_sql(:increment => 1))
         assert_equal(" INCREMENT BY 2", sequence_options_sql(:increment => 2))
       end
-      
+
       should "not include the option if nil value specified" do
         assert_equal("", sequence_options_sql(:increment => nil))
       end
     end
-    
+
     context "for :min" do
       should "include 'MINVALUE' in the SQL if specified" do
         assert_equal(" MINVALUE 1", sequence_options_sql(:min => 1))
         assert_equal(" MINVALUE 2", sequence_options_sql(:min => 2))
       end
-      
+
       should "not include 'MINVALUE' in SQL if set to nil" do
         assert_equal("", sequence_options_sql(:min => nil))
       end
-      
+
       should "set 'NO MINVALUE' if :min specified as false" do
         assert_equal(" NO MINVALUE", sequence_options_sql(:min => false))
       end
     end
-    
+
     context "for :max" do
       should "include 'MAXVALUE' in the SQL if specified" do
         assert_equal(" MAXVALUE 1", sequence_options_sql(:max => 1))
         assert_equal(" MAXVALUE 2", sequence_options_sql(:max => 2))
       end
-      
+
       should "not include 'MAXVALUE' in SQL if set to nil" do
         assert_equal("", sequence_options_sql(:max => nil))
       end
-      
+
       should "set 'NO MAXVALUE' if :min specified as false" do
         assert_equal(" NO MAXVALUE", sequence_options_sql(:max => false))
       end
     end
-    
+
     context "for :start" do
       should "include 'START WITH' in SQL if specified" do
         assert_equal(" START WITH 1", sequence_options_sql(:start => 1))
         assert_equal(" START WITH 2", sequence_options_sql(:start => 2))
         assert_equal(" START WITH 500", sequence_options_sql(:start => 500))
       end
-      
+
       should "not include 'START WITH' in SQL if specified as nil" do
         assert_equal("", sequence_options_sql(:start => nil))
       end
     end
-    
+
     context "for :cache" do
       should "include 'CACHE' in SQL if specified" do
         assert_equal(" CACHE 1", sequence_options_sql(:cache => 1))
@@ -75,16 +75,16 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
         assert_equal(" CACHE 500", sequence_options_sql(:cache => 500))
       end
     end
-    
+
     context "for :cycle" do
       should "include 'CYCLE' option if specified" do
         assert_equal(" CYCLE", sequence_options_sql(:cycle => true))
       end
-      
+
       should "include 'NO CYCLE' option if set as false" do
         assert_equal(" NO CYCLE", sequence_options_sql(:cycle => false))
       end
-      
+
       should "not include 'CYCLE' statement if specified as nil" do
         assert_equal("", sequence_options_sql(:cycle => nil))
       end
@@ -94,7 +94,7 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
       assert_equal " INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE", sequence_options_sql(@options.merge(:start => 1))
     end
   end # generating sequence option SQL
-  
+
   context "creating sequences" do
     context "without options" do
       should "generate the proper SQL" do
@@ -102,14 +102,14 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
         assert_equal("CREATE SEQUENCE blahs", create_sequence_sql('blahs'))
       end
     end
-    
+
     context "with options" do
       should "include options at the end" do
         assert_equal("CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE", create_sequence_sql('things', @options.merge(:start => 1)))
       end
     end
   end # creating sequences
-  
+
   context "altering sequences" do
     context "without options" do
       should "return a blank SQL statement" do
@@ -118,21 +118,21 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
         assert_equal("", change_sequence_sql('things', nil))
       end
     end
-    
+
     context "with options" do
-      
+
       should "include options at the end" do
         assert_equal("ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE", change_sequence_sql('things', @options.merge(:restart => 1)))
       end
     end
-    
+
   end # altering sequences
-  
+
   context "dropping sequences" do
     should "generate the proper SQL" do
       assert_equal("DROP SEQUENCE seq_users", drop_sequence_sql('seq_users'))
       assert_equal("DROP SEQUENCE seq_items", drop_sequence_sql('seq_items'))
     end
   end # dropping sequences
-  
+
 end

--- a/test/unit/schema_dumper_test.rb
+++ b/test/unit/schema_dumper_test.rb
@@ -1,56 +1,56 @@
 require 'helper'
 
-class SchemaDumperTest < ActiveSupport::TestCase
-  
+class SchemaDumperTest < Test::Unit::TestCase
+
   class SequenceDefinition < Struct.new(:name, :options); end
-  
+
   class MockConnection
     attr_accessor :sequences
-    
+
     def initialize(sequences = [])
       @sequences = sequences
     end
-    
+
   end
-  
+
   class MockStream
     attr_accessor :output
     def initialize; @output = []; end
     def puts(str = ""); @output << str; end
     def to_s; @output.join("\n"); end
   end
-  
+
   class MockSchemaDumper
     def initialize(connection)
       @connection = connection
     end
-    
+
     def self.dump(conn, stream)
       new(conn).dump(stream)
     end
-    
+
     def header(stream)
       stream.puts '# Fake Schema Header'
     end
-    
+
     def tables(stream)
       stream.puts '# (No Tables)'
     end
-    
+
     def dump(stream)
       header(stream)
       tables(stream)
       trailer(stream)
       stream
     end
-    
+
     def trailer(stream)
       stream.puts '# Fake Schema Trailer'
     end
-    
+
     include PgSequencer::SchemaDumper
   end
-  
+
   context "dumping the schema" do
     setup do
       @options = {
@@ -71,7 +71,7 @@ class SchemaDumperTest < ActiveSupport::TestCase
       end
 
       @conn = MockConnection.new(sequences)
-      
+
       expected_output = <<-SCHEMAEND
 # Fake Schema Header
 # (No Tables)

--- a/test/unit/schema_dumper_test.rb
+++ b/test/unit/schema_dumper_test.rb
@@ -21,8 +21,9 @@ class SchemaDumperTest < Test::Unit::TestCase
   end
 
   class MockSchemaDumper
-    def initialize(connection)
+    def initialize(connection, dump)
       @connection = connection
+      @dump = dump
     end
 
     def self.dump(conn, stream)
@@ -63,6 +64,7 @@ class SchemaDumperTest < Test::Unit::TestCase
       }
 
       @stream = MockStream.new
+      @dump = OpenStruct.new(final: "")
     end
 
     should "output all sequences correctly" do
@@ -72,17 +74,20 @@ class SchemaDumperTest < Test::Unit::TestCase
 
       @conn = MockConnection.new(sequences)
 
-      expected_output = <<-SCHEMAEND
+      expected_stream_output = <<-SCHEMAEND
 # Fake Schema Header
 # (No Tables)
-  create_sequence "seq_t_item", :increment => 1, :min => 1, :max => 2000000, :start => 1, :cache => 5, :cycle => true
-  create_sequence "seq_t_user", :increment => 1, :min => 1, :max => 2000000, :start => 1, :cache => 5, :cycle => true
-
 # Fake Schema Trailer
 SCHEMAEND
 
-      MockSchemaDumper.dump(@conn, @stream)
-      assert_equal(expected_output.strip, @stream.to_s)
+      expected_dump_final_output = <<-SCHEMAEND
+  create_sequence "seq_t_item", :increment => 1, :min => 1, :max => 2000000, :start => 1, :cache => 5, :cycle => true
+  create_sequence "seq_t_user", :increment => 1, :min => 1, :max => 2000000, :start => 1, :cache => 5, :cycle => true
+SCHEMAEND
+
+      MockSchemaDumper.new(@conn, @dump).dump(@stream)
+      assert_equal(expected_stream_output.strip, @stream.to_s)
+      assert_equal(expected_dump_final_output.strip, @dump.final.strip)
     end
 
     context "when min specified as false" do
@@ -94,17 +99,20 @@ SCHEMAEND
       end
 
       should "properly quote false values in schema output" do
-        expected_output = <<-SCHEMAEND
+        expected_stream_output = <<-SCHEMAEND
 # Fake Schema Header
 # (No Tables)
-  create_sequence "seq_t_item", :increment => 1, :min => false, :max => 2000000, :start => 1, :cache => 5, :cycle => true
-  create_sequence "seq_t_user", :increment => 1, :min => false, :max => 2000000, :start => 1, :cache => 5, :cycle => true
-
 # Fake Schema Trailer
 SCHEMAEND
 
-        MockSchemaDumper.dump(@conn, @stream)
-        assert_equal(expected_output.strip, @stream.to_s)
+      expected_dump_final_output = <<-SCHEMAEND
+  create_sequence "seq_t_item", :increment => 1, :min => false, :max => 2000000, :start => 1, :cache => 5, :cycle => true
+  create_sequence "seq_t_user", :increment => 1, :min => false, :max => 2000000, :start => 1, :cache => 5, :cycle => true
+SCHEMAEND
+
+      MockSchemaDumper.new(@conn, @dump).dump(@stream)
+      assert_equal(expected_stream_output.strip, @stream.to_s)
+      assert_equal(expected_dump_final_output.strip, @dump.final.strip)
       end
     end
   end


### PR DESCRIPTION
After upgrading to Rails 4.2.X & doing all the associated gem upgrades, we were no longer able to run bin/rake db:schema:dump because we got this error:

```
NoMethodError: private method `puts' called for nil:NilClass
…/gems/pg_sequencer-8bbafc5bbc23/lib/pg_sequencer/schema_dumper.rb:28:in `sequences'
```

After some digging, I was able to determine that that schema_plus_core’s schema_dumper no longer passes around the stream like it used to, and appending to `@dump.final` seemed like the simplest way to recreate the old schema dump file, which always just had the pg_sequencer sequences at the very end.
