### PR TITLE
Use prepend and super in preference to alias_method_chain

### DIFF
--- a/lib/pg_sequencer/railtie.rb
+++ b/lib/pg_sequencer/railtie.rb
@@ -19,7 +19,7 @@ module PgSequencer
         end
 
         ActiveRecord::SchemaDumper.class_eval do
-          include PgSequencer::SchemaDumper
+          prepend PgSequencer::SchemaDumper
         end
 
       end

--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -2,12 +2,8 @@ module PgSequencer
   module SchemaDumper
     extend ActiveSupport::Concern
 
-    included do
-      alias_method_chain :tables, :sequences
-    end
-
     def tables_with_sequences(stream)
-      tables_without_sequences(stream)
+      super
       sequences
     end
 

--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -2,7 +2,7 @@ module PgSequencer
   module SchemaDumper
     extend ActiveSupport::Concern
 
-    def tables_with_sequences(stream)
+    def tables(stream)
       super
       sequences
     end

--- a/test/unit/schema_dumper_test.rb
+++ b/test/unit/schema_dumper_test.rb
@@ -49,7 +49,7 @@ class SchemaDumperTest < Test::Unit::TestCase
       stream.puts '# Fake Schema Trailer'
     end
 
-    include PgSequencer::SchemaDumper
+    prepend PgSequencer::SchemaDumper
   end
 
   context "dumping the schema" do


### PR DESCRIPTION
This change makes it possible to use pg_sequencer in an app that also uses schema_plus.  Basically, schema_plus's internal dependency schema_monkey relies on `super` to do a lot of its patching work, and `alias_method_chain` breaks that.  See https://github.com/SchemaPlus/schema_monkey/issues/4 for details.

This will break support for Ruby 1.8 and 1.9; I'm not sure if those are officially supported anyway.
